### PR TITLE
[app] prevent the main element being expanded

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -135,7 +135,7 @@
             </div>
           </div>
         </aside>
-        <main class="order-1 ms-0 ms-lg-3 me-lg-2" style="grid-area: main;margin-top: 4.6rem">
+        <main class="overflow-hidden order-1 ms-0 ms-lg-3 me-lg-2" style="grid-area: main;margin-top: 4.6rem">
           <div>
             <router-outlet></router-outlet>
           </div>

--- a/src/app/sega/maimai2/maimai2-songlist/maimai2-songlist.component.html
+++ b/src/app/sega/maimai2/maimai2-songlist/maimai2-songlist.component.html
@@ -121,7 +121,7 @@
            (error)="imgError($event)"
            alt="{{song.name}}">
     </div>
-    <div class="overflow-hidden px-3 py-1" style="width: 100%;">
+    <div class="overflow-hidden px-3 py-1 w-100">
       <div class="song-info-title text-truncate fw-bold">
         <div class="overflow-hidden" style="margin-right: 0.5rem; white-space: nowrap; text-overflow: ellipsis;">
             <span style="font-size: 0.75rem;">{{song.musicId}}. </span>


### PR DESCRIPTION
原问题：舞萌DX -> 乐曲列表 -> 搜索 -> 若い力 -SEGA HARD GIRLS MIX-

名字过长导致main元素被撑大